### PR TITLE
Set the default ACL to 'public-read' for files uploaded to Amazon

### DIFF
--- a/lib/imager.js
+++ b/lib/imager.js
@@ -379,7 +379,7 @@ Imager.prototype = {
     var self = this;
     var client = knox.createClient(this.config['storage'][this.storage]);
 
-    client.putFile(file, remoteFile, function (err, res) {
+    client.putFile(file, remoteFile, { 'x-amz-acl': 'public-read' }, function (err, res) {
       if (err) return cb(err);
       log(remoteFile + ' uploaded');
       // remove the file after successful upload


### PR DESCRIPTION
Hi,

All files uploaded to Amazon (using knox) have their defaults so that they can only be read by the owner, which means that no thumbnails will be publicly accessible (probably not what you want when you've generated thumbnails).

I've gone ahead and changed the default to public read, so that the files can be accessed once they're uploaded.

However, perhaps one want to change the permissions on a per-variant basis (e.g storing the original version without public access)? I haven't implemented that since I'd have to go over and change most internal API:s, making sure they are also compatible with CloudFront.

What are your thoughts on this?
