### PR TITLE
Only send x-amz-storage-class header if storageClass is set in config.

### DIFF
--- a/lib/imager.js
+++ b/lib/imager.js
@@ -380,10 +380,16 @@ Imager.prototype = {
 
   pushToS3: function (file, remoteFile, filename, type, cb) {
     var self = this;
-    var client = knox.createClient(this.config['storage'][this.storage]);
+    var s3Config = this.config['storage'][this.storage];
+    var client = knox.createClient(s3Config);
     var directory = this.config['storage']['uploadDirectory'] || '';
 
-    client.putFile(file, directory + remoteFile, { 'x-amz-acl': 'public-read', 'x-amz-storage-class': this.config['storage'][this.storage]['storageClass'] }, function (err, res) {
+    var options = { 'x-amz-acl': 'public-read' };
+    if(s3Config.storageClass) {
+      options['x-amz-storage-class'] = s3Config.storageClass;
+    }
+
+    client.putFile(file, directory + remoteFile, options, function (err, res) {
       if (err) return cb(err);
       log(remoteFile + ' uploaded');
       // remove the file after successful upload


### PR DESCRIPTION
Version 0.1.10 breaks my uploads to S3, (although the debugger says everything is a-ok). Nailed it down to the x-amz-storage-class header being sent empty unless explicitly configured. Hence the header should only be sent if the storageClass is set. 
