### PR TITLE
[Error: The storage you have specified does not exist] when the Array prototype is extended

### DIFF
--- a/lib/imager.js
+++ b/lib/imager.js
@@ -53,11 +53,11 @@ var Imager = module.exports = function Imager (config, storage) {
     storage = [storage];
   }
 
-  for (var i in storage) {
-    if (!config.storage[storage[i]]) {
+  storage.forEach(function(s) {
+    if (!config.storage[s]) {
       throw new Error('The storage you have specified does not exist');
     }
-  }
+  })
 
   for (i in config.variants) {
     if(['undefined', 'function'].indexOf(typeof config.variants[i].rename) === -1) {


### PR DESCRIPTION
The following code doesn't work correctly when the Array class is extended:

  for (var i in storage) { 
    if (!config.storage[storage[i]]) {
      throw new Error('The storage you have specified does not exist');
    }
  }

the code should be:

  storage.forEach(function(s) {
    if (!config.storage[s]) {
      throw new Error('The storage you have specified does not exist');
    }
  })

code above avoids iterations over extended methods
