### PR TITLE
Added support for multer (Express 4.x)

### DIFF
--- a/lib/imager.js
+++ b/lib/imager.js
@@ -119,7 +119,7 @@ Imager.prototype = {
       if (err) return callback(err);
 
       var prepare = function (file, fn) {
-        var ct = file['type'] || file.headers['content-type'];
+        var ct = getFileType(file);
 
         function defaultRename(filename) {
           return variant.keepNames ? path.basename(file.name) :
@@ -270,7 +270,7 @@ Imager.prototype = {
 
   resizeFile: function (file, preset, filename, cb) {
     var self = this;
-    var ct = file['type'] || file.headers['content-type'];
+    var ct = getFileType(file);
     var remoteFile = preset.name + preset.sep + filename;
     var tempFile = path.join(tempDir, 'imager_' +
       Math.round(new Date().getTime()) + '_' +
@@ -306,7 +306,7 @@ Imager.prototype = {
 
   cropFile: function (file, preset, filename, cb) {
     var self = this;
-    var ct = file['type'] || file.headers['content-type'];
+    var ct = getFileType(file);
     var remoteFile = preset.name + preset.sep + filename;
     var tempFile = path.join(tempDir, 'imager_' +
       Math.round(new Date().getTime()) + '_' +
@@ -349,7 +349,7 @@ Imager.prototype = {
 
   resizeAndCropFile: function (file, preset, filename, cb) {
     var self = this;
-    var ct = file['type'] || file.headers['content-type'];
+    var ct = getFileType(file);
     var remoteFile = preset.name + preset.sep + filename;
     var tempFile = path.join(tempDir, 'imager_' +
       Math.round(new Date().getTime()) + '_' +
@@ -754,3 +754,7 @@ function getFileInfo (file, cb) {
   file = f;
   cb(null, file);
 };
+
+function getFileType(file) {
+  return (file['type'] || file['mimetype']) || file.headers['content-type'];
+}


### PR DESCRIPTION
Added support for multer (Express 4.x)

multer stores the file type in file["mimetype"] and there is no headers.
Without the fix it would crash when using multer
