### PR TITLE
Add file.headers check to getFileInfo.type

### DIFF
--- a/lib/imager.js
+++ b/lib/imager.js
@@ -831,7 +831,7 @@ function getFileInfo (file, cb) {
 
   var f = {
     size: typeof(file) == 'string' ? fs.statSync(file).size : file.size,
-    type: typeof(file) == 'string' ? mime.lookup(file) : file.type || file.mimetype,
+    type: typeof(file) == 'string' ? mime.lookup(file) : file.type || file.mimetype || file.headers['content-type'],
     name: typeof(file) == 'string' ? file.split('/')[file.split('/').length - 1] : file.name,
     path: typeof(file) == 'string' ? file : file.path
   };


### PR DESCRIPTION
This small change allows support for multiparty - Otherwise the file type check fails at line 843 as file.headers['content-type'] has been stripped at that point.
